### PR TITLE
Integrating with nrfx: blinky compiles for nrf52810

### DIFF
--- a/fw/2.0/hw/bsp/nrf52810dk/include/bsp/bsp.h
+++ b/fw/2.0/hw/bsp/nrf52810dk/include/bsp/bsp.h
@@ -45,7 +45,8 @@ extern uint8_t _ram_start;
 #define LED_3           (19)
 #define LED_4           (20)
 #define LED_0_PIN   (LED_1)
-
+#define LED_BLINK_PIN   (LED_1)
+    
 #define FRIDGE_PIN (5)
 #define SDA_PIN (31)
 #define SCL_PIN (30)

--- a/fw/2.0/hw/bsp/nrf52810dk/pkg.yml
+++ b/fw/2.0/hw/bsp/nrf52810dk/pkg.yml
@@ -26,57 +26,81 @@ pkg.keywords:
     - nrf52
     - nrf52dk
 
+
 pkg.cflags:
     # Nordic SDK files require these defines.
-    - '-DADC_ENABLED=0'
-    - '-DCLOCK_ENABLED=1'
-    - '-DCOMP_ENABLED=1'
-    - '-DEGU_ENABLED=0'
-    - '-DGPIOTE_ENABLED=1'
-    - '-DI2S_ENABLED=1'
-    - '-DLPCOMP_ENABLED=1'
-    - '-DNRF52'
-    - '-DPDM_ENABLED=0'
-    - '-DPERIPHERAL_RESOURCE_SHARING_ENABLED=1'
-    - '-DPWM0_ENABLED=1'
-    - '-DPWM1_ENABLED=0'
-    - '-DPWM2_ENABLED=0'
-    - '-DQDEC_ENABLED=1'
-    - '-DRNG_ENABLED=1'
-    - '-DRTC0_ENABLED=0'
-    - '-DRTC1_ENABLED=0'
-    - '-DRTC2_ENABLED=0'
-    - '-DSAADC_ENABLED=1'
-    - '-DSPI_MASTER_0_ENABLE=1'
-    - '-DSPI0_CONFIG_MISO_PIN=25'
-    - '-DSPI0_CONFIG_MOSI_PIN=24'
-    - '-DSPI0_CONFIG_SCK_PIN=23'
-    - '-DSPI0_ENABLED=1'
-    - '-DSPI0_USE_EASY_DMA=1'
-    - '-DSPI1_ENABLED=0'
-    - '-DSPI2_ENABLED=0'
-    - '-DSPIS0_CONFIG_MISO_PIN=25'
-    - '-DSPIS0_CONFIG_MOSI_PIN=24'
-    - '-DSPIS0_CONFIG_SCK_PIN=23'
-    - '-DSPIS0_ENABLED=1'
-    - '-DSPIS1_CONFIG_MISO_PIN=4'
-    - '-DSPIS1_CONFIG_MOSI_PIN=3'
-    - '-DSPIS1_CONFIG_SCK_PIN=2'
-    - '-DSPIS1_ENABLED=0'
-    - '-DSPIS2_ENABLED=0'
-    - '-DTIMER0_ENABLED=1'
-    - '-DTIMER1_ENABLED=0'
-    - '-DTIMER2_ENABLED=0'
-    - '-DTIMER3_ENABLED=0'
-    - '-DTIMER4_ENABLED=0'
-    - '-DTWI0_CONFIG_SCL=27'
-    - '-DTWI0_CONFIG_SDA=26'
-    - '-DTWI0_ENABLED=1'
-    - '-DTWI1_ENABLED=1'
-    - '-DTWIS0_ENABLED=1'
-    - '-DTWIS1_ENABLED=0'
-    - '-DUART0_ENABLED=1'
-    - '-DWDT_ENABLED=1'
+     - '-DNRFX_CLOCK_ENABLED=0'
+     - '-DNRFX_COMP_ENABLED=0'
+     - '-DNRFX_GPIOTE_ENABLED=0'
+     - '-DNRFX_I2S_ENABLED=0'
+     - '-DNRFX_LPCOMP_ENABLED=0'
+     - '-DNRF52'
+     - '-DNRFX_PDM_ENABLED=0'
+     - '-DNRFX_POWER_ENABLED=0'
+     - '-DNRFX_PPI_ENABLED=0'
+     - '-DNRFX_PRS_ENABLDE=0'
+     - '-DNRFX_QDEC_ENABLED=0'
+     - '-DNRFX_RNG_ENABLED=0'
+     - '-DNRFX_RTC_ENABLED=0'
+     - '-DNRFX_SPIM_ENABLED=0'
+     - '-DNRFX_SPIS_ENABLED=0'
+     - '-DNRFX_SPI_ENABLED=0'
+     - '-DNRFX_SWI_ENABLED=0'
+     - '-DNRFX_SYSTICK_ENABLED=0'
+     - '-DNRFX_TIMER_ENABLED=0'
+     - '-DNRFX_TWIM_ENABLED=0'
+     - '-DNRFX_TWIS_ENABLED=0'
+     - '-DNRFX_TWI_ENABLED=0'
+     - '-DNRFX_UARTE_ENABLED=0'
+     - '-DNRFX_UART_ENABLED=0'
+     - '-DNRFX_WDT_ENABLED=0'
+
+pkg.cflags.ADC_0:
+     - '-DNRFX_SAADC_ENABLED=1'
+     - '-DNRFX_SAADC_CONFIG_RESOLUTION=1'
+     - '-DNRFX_SAADC_CONFIG_OVERSAMPLE=0'
+     - '-DNRFX_SAADC_CONFIG_LP_MODE=0'
+     - '-DNRFX_SAADC_CONFIG_IRQ_PRIORITY=7'
+
+pkg.cflags.PWM_0:
+     - '-DNRFX_PWM_ENABLED=1'
+     - '-DNRFX_PWM0_ENABLED=1'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_OUT0_PIN=0xff'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_OUT1_PIN=0xff'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_OUT2_PIN=0xff'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_OUT3_PIN=0xff'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_BASE_CLOCK=4'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_COUNT_MODE=0'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_TOP_VALUE=1000'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_LOAD_MODE=0'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_STEP_MODE=0'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY=7'
+
+pkg.cflags.PWM_1:
+     - '-DNRFX_PWM1_ENABLED=1'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_OUT0_PIN=0xff'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_OUT1_PIN=0xff'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_OUT2_PIN=0xff'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_OUT3_PIN=0xff'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_BASE_CLOCK=4'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_COUNT_MODE=0'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_TOP_VALUE=1000'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_LOAD_MODE=0'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_STEP_MODE=0'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY=7'
+
+pkg.cflags.PWM_2:
+     - '-DNRFX_PWM2_ENABLED=1'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_OUT0_PIN=0xff'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_OUT1_PIN=0xff'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_OUT2_PIN=0xff'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_OUT3_PIN=0xff'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_BASE_CLOCK=4'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_COUNT_MODE=0'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_TOP_VALUE=1000'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_LOAD_MODE=0'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_STEP_MODE=0'
+     - '-DNRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY=7'
 
 pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
@@ -93,6 +117,18 @@ pkg.deps.UART_0:
 
 pkg.deps.UART_1:
     - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
+
+pkg.deps.ADC_0:
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
+
+pkg.deps.PWM_0:
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
+
+pkg.deps.PWM_1:
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
+
+pkg.deps.PWM_2:
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.SOFT_PWM:
     - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/fw/2.0/hw/bsp/nrf52810dk/src/hal_bsp.c
+++ b/fw/2.0/hw/bsp/nrf52810dk/src/hal_bsp.c
@@ -43,7 +43,11 @@
 #endif
 #include "os/os_dev.h"
 #include "bsp.h"
-#if MYNEWT_VAL(PWM)
+#if MYNEWT_VAL(ADC_0)
+#include <adc_nrf52/adc_nrf52.h>
+#include <nrfx_saadc.h>
+#endif
+#if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
 #endif
 #if MYNEWT_VAL(SOFT_PWM)
@@ -92,12 +96,15 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(PWM_0)
 static struct pwm_dev os_bsp_pwm0;
+int pwm0_idx;
 #endif
 #if MYNEWT_VAL(PWM_1)
 static struct pwm_dev os_bsp_pwm1;
+int pwm1_idx;
 #endif
 #if MYNEWT_VAL(PWM_2)
 static struct pwm_dev os_bsp_pwm2;
+int pwm2_idx;
 #endif
 #if MYNEWT_VAL(SOFT_PWM)
 static struct pwm_dev os_bsp_spwm;
@@ -207,31 +214,44 @@ hal_bsp_init(void)
     assert(rc == 0);
 #endif
 
+#if MYNEWT_VAL(ADC_0)
+rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
+                   "adc0",
+                   OS_DEV_INIT_KERNEL,
+                   OS_DEV_INIT_PRIO_DEFAULT,
+                   nrf52_adc_dev_init,
+                   &os_bsp_adc0_config);
+assert(rc == 0);
+#endif
+
 #if MYNEWT_VAL(PWM_0)
+    pwm0_idx = 0;
     rc = os_dev_create((struct os_dev *) &os_bsp_pwm0,
                        "pwm0",
                        OS_DEV_INIT_KERNEL,
                        OS_DEV_INIT_PRIO_DEFAULT,
                        nrf52_pwm_dev_init,
-                       NULL);
+                       &pwm0_idx);
     assert(rc == 0);
 #endif
 #if MYNEWT_VAL(PWM_1)
+    pwm1_idx = 1;
     rc = os_dev_create((struct os_dev *) &os_bsp_pwm1,
                        "pwm1",
                        OS_DEV_INIT_KERNEL,
                        OS_DEV_INIT_PRIO_DEFAULT,
                        nrf52_pwm_dev_init,
-                       NULL);
+                       &pwm1_idx);
     assert(rc == 0);
 #endif
 #if MYNEWT_VAL(PWM_2)
+    pwm2_idx = 2;
     rc = os_dev_create((struct os_dev *) &os_bsp_pwm2,
                        "pwm2",
                        OS_DEV_INIT_KERNEL,
                        OS_DEV_INIT_PRIO_DEFAULT,
                        nrf52_pwm_dev_init,
-                       NULL);
+                       &pwm2_idx);
     assert(rc == 0);
 #endif
 #if MYNEWT_VAL(SOFT_PWM)

--- a/fw/2.0/hw/bsp/nrf52810dk/syscfg.yml
+++ b/fw/2.0/hw/bsp/nrf52810dk/syscfg.yml
@@ -68,26 +68,6 @@ syscfg.defs:
         description: 'NRF52 RTC 0'
         value:  0
 
-    PWM_0:
-        description: 'NRF52 PWM 0'
-        value: 0
-
-    PWM_1:
-        description: 'NRF52 PWM 1'
-        value: 0
-
-    PWM_2:
-        description: 'NRF52 PWM 2'
-        value: 0
-
-    PWM:
-        description: 'NRF52 PWM'
-        value: 0
-
-    SOFT_PWM:
-        description: 'SOFT PWM'
-        value: 0
-
 syscfg.defs.BLE_LP_CLOCK:
     TIMER_0:
         value: 0


### PR DESCRIPTION
This PR changes the nrf52810dk BSP to work with the mynewt-core's current MCU package for nordic chips. 
Changes will soon be made to mynewt-core mcu/nordic in order to have all the definitions required for this chip.